### PR TITLE
Refactor: revamp vars in shipper

### DIFF
--- a/pkg/commands/artifact/add.go
+++ b/pkg/commands/artifact/add.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"strings"
+
 	"github.com/gimlet-io/gimlet-cli/pkg/dx"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
-	"strings"
 )
 
 var artifactAddCmd = cli.Command{
@@ -59,6 +60,12 @@ func add(c *cli.Context) error {
 			return fmt.Errorf("--field should follow a key=value format")
 		}
 		item[keyValue[0]] = keyValue[1]
+
+		if a.Vars == nil {
+			a.Vars = map[string]string{}
+		}
+		a.Vars[keyValue[0]] = keyValue[1]
+
 	}
 	if len(item) != 0 {
 		a.Items = append(a.Items, item)

--- a/pkg/commands/artifact/add.go
+++ b/pkg/commands/artifact/add.go
@@ -94,6 +94,10 @@ func add(c *cli.Context) error {
 			a.Context = map[string]string{}
 		}
 		a.Context[k] = v
+		if a.Vars == nil {
+			a.Vars = map[string]string{}
+		}
+		a.Vars[k] = v
 	}
 
 	jsonString := bytes.NewBufferString("")

--- a/pkg/commands/artifact/add_test.go
+++ b/pkg/commands/artifact/add_test.go
@@ -212,35 +212,5 @@ func Test_add(t *testing.T) {
 			g.Assert(len(a.Vars) == 3).IsTrue("Should have 3 variables in vars")
 			g.Assert(a.Vars["KEY3"] == "VALUE3").IsTrue("Should append variable to var")
 		})
-		g.It("Should add vars variables to artifact", func() {
-			args := strings.Split("gimlet artifact add", " ")
-			args = append(args, "-f", artifactFile.Name())
-			args = append(args, "--var", "BRANCH=TEST")
-			args = append(args, "--var", "REPO=TEST/TEST")
-			err = commands.Run(&Command, args)
-			g.Assert(err == nil).IsTrue(err)
-
-			content, err := ioutil.ReadFile(artifactFile.Name())
-			var a dx.Artifact
-			err = json.Unmarshal(content, &a)
-			g.Assert(err == nil).IsTrue(err)
-			g.Assert(len(a.Vars) == 5).IsTrue("Should have 5 vars in context")
-			g.Assert(a.Vars["BRANCH"] == "TEST").IsTrue("Should add var")
-			g.Assert(a.Vars["REPO"] == "TEST/TEST").IsTrue("Should add var")
-		})
-		g.It("Should append vars variable to artifact", func() {
-			args := strings.Split("gimlet artifact add", " ")
-			args = append(args, "-f", artifactFile.Name())
-			args = append(args, "--var", "SHA=a94a8fe5ccb19ba61c4c0873d391e987982fbbd3")
-			err = commands.Run(&Command, args)
-			g.Assert(err == nil).IsTrue(err)
-
-			content, err := ioutil.ReadFile(artifactFile.Name())
-			var a dx.Artifact
-			err = json.Unmarshal(content, &a)
-			g.Assert(err == nil).IsTrue(err)
-			g.Assert(len(a.Vars) == 6).IsTrue("Should have 6 vars in vars")
-			g.Assert(a.Vars["SHA"] == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3").IsTrue("Should append var")
-		})
 	})
 }

--- a/pkg/commands/artifact/add_test.go
+++ b/pkg/commands/artifact/add_test.go
@@ -193,6 +193,8 @@ func Test_add(t *testing.T) {
 			g.Assert(err == nil).IsTrue(err)
 			g.Assert(len(a.Context) == 2).IsTrue("Should have 2 vars in context")
 			g.Assert(a.Context["KEY"] == "VALUE").IsTrue("Should add var")
+			g.Assert(len(a.Vars) == 2).IsTrue("Should have 2 variables in vars")
+			g.Assert(a.Vars["KEY"] == "VALUE").IsTrue("Should add variable to vars")
 		})
 		g.It("Should append context variable to artifact", func() {
 			args := strings.Split("gimlet artifact add", " ")
@@ -206,7 +208,9 @@ func Test_add(t *testing.T) {
 			err = json.Unmarshal(content, &a)
 			g.Assert(err == nil).IsTrue(err)
 			g.Assert(len(a.Context) == 3).IsTrue("Should have 3 vars in context")
-			g.Assert(a.Context["KEY3"] == "VALUE3").IsTrue("Should append var")
+			g.Assert(a.Context["KEY3"] == "VALUE3").IsTrue("Should append var to context")
+			g.Assert(len(a.Vars) == 3).IsTrue("Should have 3 variables in vars")
+			g.Assert(a.Vars["KEY3"] == "VALUE3").IsTrue("Should append variable to var")
 		})
 		g.It("Should add vars variables to artifact", func() {
 			args := strings.Split("gimlet artifact add", " ")
@@ -220,9 +224,9 @@ func Test_add(t *testing.T) {
 			var a dx.Artifact
 			err = json.Unmarshal(content, &a)
 			g.Assert(err == nil).IsTrue(err)
-			g.Assert(len(a.Context) == 5).IsTrue("Should have 5 vars in context")
-			g.Assert(a.Context["BRANCH"] == "TEST").IsTrue("Should add var")
-			g.Assert(a.Context["REPO"] == "TEST/TEST").IsTrue("Should add var")
+			g.Assert(len(a.Vars) == 5).IsTrue("Should have 5 vars in context")
+			g.Assert(a.Vars["BRANCH"] == "TEST").IsTrue("Should add var")
+			g.Assert(a.Vars["REPO"] == "TEST/TEST").IsTrue("Should add var")
 		})
 		g.It("Should append vars variable to artifact", func() {
 			args := strings.Split("gimlet artifact add", " ")

--- a/pkg/commands/artifact/add_test.go
+++ b/pkg/commands/artifact/add_test.go
@@ -89,6 +89,9 @@ func Test_add(t *testing.T) {
 			g.Assert(len(a.Items) == 1).IsTrue("Should have 1 item")
 			g.Assert(a.Items[0]["name"] == "CI").IsTrue("Should add CI item")
 			g.Assert(a.Items[0]["url"] == "https://jenkins.example.com/job/dev/84/display/redirect").IsTrue("Should add URL item")
+			g.Assert(len(a.Vars) == 2).IsTrue("Should have 2 vars")
+			g.Assert(a.Vars["name"] == "CI").IsTrue("Should add CI var")
+			g.Assert(a.Vars["url"] == "https://jenkins.example.com/job/dev/84/display/redirect").IsTrue("Should add URL var")
 		})
 		g.It("Should append custom field to artifact", func() {
 			args := strings.Split("gimlet artifact add", " ")
@@ -126,6 +129,8 @@ func Test_add(t *testing.T) {
 			g.Assert(err == nil).IsTrue(err)
 			g.Assert(len(a.Items) == 2).IsTrue("Should have 2 items")
 			g.Assert(a.Items[1]["custom"] == "myValue").IsTrue("Should add custom item")
+			g.Assert(len(a.Vars) == 3).IsTrue("Should have 3 vars")
+			g.Assert(a.Vars["custom"] == "myValue").IsTrue("Should add custom var")
 		})
 		g.It("Should add Gimlet environment to artifact", func() {
 			args := strings.Split("gimlet artifact add", " ")
@@ -193,7 +198,7 @@ func Test_add(t *testing.T) {
 			g.Assert(err == nil).IsTrue(err)
 			g.Assert(len(a.Context) == 2).IsTrue("Should have 2 vars in context")
 			g.Assert(a.Context["KEY"] == "VALUE").IsTrue("Should add var")
-			g.Assert(len(a.Vars) == 2).IsTrue("Should have 2 variables in vars")
+			g.Assert(len(a.Vars) == 5).IsTrue("Should have 5 variables in vars")
 			g.Assert(a.Vars["KEY"] == "VALUE").IsTrue("Should add variable to vars")
 		})
 		g.It("Should append context variable to artifact", func() {
@@ -209,7 +214,7 @@ func Test_add(t *testing.T) {
 			g.Assert(err == nil).IsTrue(err)
 			g.Assert(len(a.Context) == 3).IsTrue("Should have 3 vars in context")
 			g.Assert(a.Context["KEY3"] == "VALUE3").IsTrue("Should append var to context")
-			g.Assert(len(a.Vars) == 3).IsTrue("Should have 3 variables in vars")
+			g.Assert(len(a.Vars) == 6).IsTrue("Should have 6 variables in vars")
 			g.Assert(a.Vars["KEY3"] == "VALUE3").IsTrue("Should append variable to var")
 		})
 	})

--- a/pkg/commands/artifact/add_test.go
+++ b/pkg/commands/artifact/add_test.go
@@ -208,5 +208,35 @@ func Test_add(t *testing.T) {
 			g.Assert(len(a.Context) == 3).IsTrue("Should have 3 vars in context")
 			g.Assert(a.Context["KEY3"] == "VALUE3").IsTrue("Should append var")
 		})
+		g.It("Should add vars variables to artifact", func() {
+			args := strings.Split("gimlet artifact add", " ")
+			args = append(args, "-f", artifactFile.Name())
+			args = append(args, "--var", "BRANCH=TEST")
+			args = append(args, "--var", "REPO=TEST/TEST")
+			err = commands.Run(&Command, args)
+			g.Assert(err == nil).IsTrue(err)
+
+			content, err := ioutil.ReadFile(artifactFile.Name())
+			var a dx.Artifact
+			err = json.Unmarshal(content, &a)
+			g.Assert(err == nil).IsTrue(err)
+			g.Assert(len(a.Context) == 5).IsTrue("Should have 5 vars in context")
+			g.Assert(a.Context["BRANCH"] == "TEST").IsTrue("Should add var")
+			g.Assert(a.Context["REPO"] == "TEST/TEST").IsTrue("Should add var")
+		})
+		g.It("Should append vars variable to artifact", func() {
+			args := strings.Split("gimlet artifact add", " ")
+			args = append(args, "-f", artifactFile.Name())
+			args = append(args, "--var", "SHA=a94a8fe5ccb19ba61c4c0873d391e987982fbbd3")
+			err = commands.Run(&Command, args)
+			g.Assert(err == nil).IsTrue(err)
+
+			content, err := ioutil.ReadFile(artifactFile.Name())
+			var a dx.Artifact
+			err = json.Unmarshal(content, &a)
+			g.Assert(err == nil).IsTrue(err)
+			g.Assert(len(a.Vars) == 6).IsTrue("Should have 6 vars in vars")
+			g.Assert(a.Vars["SHA"] == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3").IsTrue("Should append var")
+		})
 	})
 }

--- a/pkg/commands/artifact/create.go
+++ b/pkg/commands/artifact/create.go
@@ -135,6 +135,7 @@ func create(c *cli.Context) error {
 		Context:      map[string]string{},
 		Environments: []*dx.Manifest{},
 		Items:        []map[string]interface{}{},
+		Vars:         map[string]string{},
 	}
 
 	jsonString := bytes.NewBufferString("")

--- a/pkg/dashboard/server/gimletd.go
+++ b/pkg/dashboard/server/gimletd.go
@@ -588,7 +588,7 @@ func decorateCommitsWithGimletArtifacts(commits []*Commit, config *config.Config
 	for _, c := range commits {
 		if artifact, ok := artifactsBySha[c.SHA]; ok {
 			for _, targetEnv := range artifact.Environments {
-				targetEnv.ResolveVars(artifact.Context)
+				targetEnv.ResolveVars(artifact.CollectVariables())
 				if c.DeployTargets == nil {
 					c.DeployTargets = []*DeployTarget{}
 				}

--- a/pkg/dashboard/server/hook.go
+++ b/pkg/dashboard/server/hook.go
@@ -174,7 +174,7 @@ func processStatusHook(
 	for _, c := range commits {
 		if artifact, ok := artifactsBySha[c.SHA]; ok {
 			for _, targetEnv := range artifact.Environments {
-				targetEnv.ResolveVars(artifact.Context)
+				targetEnv.ResolveVars(artifact.CollectVariables())
 				deployTargets = append(deployTargets, &model.DeployTarget{
 					App:        targetEnv.App,
 					Env:        targetEnv.Env,

--- a/pkg/dx/artifact.go
+++ b/pkg/dx/artifact.go
@@ -32,7 +32,7 @@ type Artifact struct {
 	// The releasable version
 	Version Version `json:"version,omitempty"`
 
-	// Arbitrary environment variables from CI
+	// Context field in Artifact is deprecated, please use Vars instead
 	Context map[string]string `json:"context,omitempty"`
 
 	// The complete set of Gimlet environments from the Gimlet environment files
@@ -41,8 +41,11 @@ type Artifact struct {
 	// The complete set of Gimlet environments from the Gimlet environment files
 	CueEnvironments []string `json:"cueEnvironments,omitempty"`
 
-	// CI job information, test results, Docker image information, etc
+	// Items field in Artifact is deprecated, please use Vars instead
 	Items []map[string]interface{} `json:"items,omitempty"`
+
+	// CI job information, test results, Docker image information, arbitary environment variables from CI, etc
+	Vars map[string]string `json:"vars,omitempty"`
 }
 
 func (a *Artifact) HasCleanupPolicy() bool {
@@ -54,7 +57,7 @@ func (a *Artifact) HasCleanupPolicy() bool {
 	return false
 }
 
-func (a *Artifact) Vars() map[string]string {
+func (a *Artifact) CollectVariables() map[string]string {
 	vars := map[string]string{}
 
 	for k, v := range a.Context {

--- a/pkg/dx/artifact.go
+++ b/pkg/dx/artifact.go
@@ -75,6 +75,10 @@ func (a *Artifact) CollectVariables() map[string]string {
 			}
 		}
 	}
+
+	for k, v := range a.Vars {
+		vars[k] = v
+	}
 	return vars
 }
 

--- a/pkg/dx/artifact.go
+++ b/pkg/dx/artifact.go
@@ -32,7 +32,9 @@ type Artifact struct {
 	// The releasable version
 	Version Version `json:"version,omitempty"`
 
-	// Context field in Artifact is deprecated, please use Vars instead
+	// Arbitrary environment variables from CI
+	//
+	//  Deprecated, please use Vars instead
 	Context map[string]string `json:"context,omitempty"`
 
 	// The complete set of Gimlet environments from the Gimlet environment files
@@ -41,10 +43,12 @@ type Artifact struct {
 	// The complete set of Gimlet environments from the Gimlet environment files
 	CueEnvironments []string `json:"cueEnvironments,omitempty"`
 
-	// Items field in Artifact is deprecated, please use Vars instead
+	// CI job information, test results, Docker image information, etc
+	//
+	// Deprecated, please use Vars instead
 	Items []map[string]interface{} `json:"items,omitempty"`
 
-	// CI job information, test results, Docker image information, arbitary environment variables from CI, etc
+	// CI context and arbitrary environment variables to pass along and to be used in manifest templating
 	Vars map[string]string `json:"vars,omitempty"`
 }
 

--- a/pkg/dx/artifact_test.go
+++ b/pkg/dx/artifact_test.go
@@ -25,7 +25,7 @@ func Test_vars(t *testing.T) {
 }
 `), &a)
 
-	vars := a.Vars()
+	vars := a.CollectVariables()
 	assert.Equal(t, 3, len(vars))
 	assert.Equal(t, 1, len(a.Context))
 }

--- a/pkg/gimletd/worker/gitops.go
+++ b/pkg/gimletd/worker/gitops.go
@@ -320,7 +320,7 @@ func processReleaseEvent(
 			GitopsRepo:  repoName,
 		}
 
-		err = manifest.ResolveVars(artifact.Vars())
+		err = manifest.ResolveVars(artifact.CollectVariables())
 		if err != nil {
 			deployEvent.Status = model.Failure
 			deployEvent.StatusDesc = err.Error()
@@ -493,7 +493,7 @@ func processArtifactEvent(
 			GitopsRepo:  repoName,
 		}
 
-		err = manifest.ResolveVars(artifact.Vars())
+		err = manifest.ResolveVars(artifact.CollectVariables())
 		if err != nil {
 			deployEvent.Status = model.Failure
 			deployEvent.StatusDesc = err.Error()


### PR DESCRIPTION
The `dx.Artifact` struct's `Context` and `Items` fields almost had the same behaviour. Therefore, it needed a refactor. We introduced the `Vars` field instead.

- `dx.Artifact` struct's `Context` and `Items` fields are now deprecated and they will be removed in a future release
-  We also deprecated the ` --field` flag in `gimlet artifact add`
- In the future we will use the `--var` flag only