### PR TITLE
Prevent out of order flux states

### DIFF
--- a/pkg/dashboard/server/flux.go
+++ b/pkg/dashboard/server/flux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gimlet-io/gimlet-cli/pkg/dashboard/notifications"
 	"github.com/gimlet-io/gimlet-cli/pkg/dashboard/server/streaming"
 	"github.com/gimlet-io/gimlet-cli/pkg/dashboard/store"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -55,6 +56,7 @@ func fluxEvent(w http.ResponseWriter, r *http.Request) {
 	clientHub, _ := ctx.Value("clientHub").(*streaming.ClientHub)
 	streaming.BroadcastGitopsCommitEvent(clientHub, *gitopsCommit)
 
+	logrus.Info("Saving gitops commit")
 	err = store.SaveOrUpdateGitopsCommit(gitopsCommit)
 	if err != nil {
 		log.Errorf("could not save or update gitops commit: %s", err)

--- a/pkg/dashboard/server/flux.go
+++ b/pkg/dashboard/server/flux.go
@@ -86,7 +86,10 @@ func asGitopsCommit(event fluxEvents.Event, env string) (*model.GitopsCommit, er
 func parseRev(rev string) string {
 	parts := strings.Split(rev, "/")
 	if len(parts) != 2 {
-		return "n/a"
+		parts = strings.Split(rev, ":")
+		if len(parts) != 2 {
+			return "n/a"
+		}
 	}
 
 	return parts[1]

--- a/pkg/dashboard/server/flux_test.go
+++ b/pkg/dashboard/server/flux_test.go
@@ -71,9 +71,9 @@ func testPostEndpoint(handlerFunc http.HandlerFunc, cn contextFunc, path string,
 }
 
 func Test_parseRev(t *testing.T) {
-	parsed := parseRev("main/1234567890")
+	parsed, _ := parseRev("main/1234567890")
 	assert.Equal(t, "1234567890", parsed)
 
-	parsed = parseRev("main@sha1:69b59063470310ebbd88a9156325322a124e55a3")
+	parsed, _ = parseRev("main@sha1:69b59063470310ebbd88a9156325322a124e55a3")
 	assert.Equal(t, "69b59063470310ebbd88a9156325322a124e55a3", parsed)
 }

--- a/pkg/dashboard/server/flux_test.go
+++ b/pkg/dashboard/server/flux_test.go
@@ -69,3 +69,11 @@ func testPostEndpoint(handlerFunc http.HandlerFunc, cn contextFunc, path string,
 
 	return rr.Code, rr.Body.String(), nil
 }
+
+func Test_parseRev(t *testing.T) {
+	parsed := parseRev("main/1234567890")
+	assert.Equal(t, "1234567890", parsed)
+
+	parsed = parseRev("main@sha1:69b59063470310ebbd88a9156325322a124e55a3")
+	assert.Equal(t, "69b59063470310ebbd88a9156325322a124e55a3", parsed)
+}

--- a/pkg/dashboard/store/gitopsCommit.go
+++ b/pkg/dashboard/store/gitopsCommit.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gimlet-io/gimlet-cli/pkg/dashboard/model"
 	queries "github.com/gimlet-io/gimlet-cli/pkg/dashboard/store/sql"
 	"github.com/russross/meddler"
-	"github.com/sirupsen/logrus"
 )
 
 func (db *Store) GitopsCommit(sha string) (*model.GitopsCommit, error) {
@@ -37,7 +36,7 @@ func (db *Store) GitopsCommits() ([]*model.GitopsCommit, error) {
 	return data, err
 }
 
-func (db *Store) SaveOrUpdateGitopsCommit(gitopsCommit *model.GitopsCommit) error {
+func (db *Store) SaveOrUpdateGitopsCommit(gitopsCommit *model.GitopsCommit) (bool, error) {
 	if db.driver != "sqlite3" {
 		return db.saveOrUpdateGitopsCommitWithTx(gitopsCommit)
 	} else {
@@ -45,35 +44,35 @@ func (db *Store) SaveOrUpdateGitopsCommit(gitopsCommit *model.GitopsCommit) erro
 	}
 }
 
-func (db *Store) saveOrUpdateGitopsCommitWithoutTx(gitopsCommit *model.GitopsCommit) error {
+func (db *Store) saveOrUpdateGitopsCommitWithoutTx(gitopsCommit *model.GitopsCommit) (bool, error) {
 	stmt := queries.Stmt(db.driver, queries.SelectGitopsCommitBySha)
 	savedGitopsCommit := new(model.GitopsCommit)
 	err := meddler.QueryRow(db, savedGitopsCommit, stmt, gitopsCommit.Sha)
 	if err == sql.ErrNoRows {
-		return meddler.Insert(db, "gitops_commits", gitopsCommit)
+		return true, meddler.Insert(db, "gitops_commits", gitopsCommit)
 	} else if err != nil {
-		return err
+		return false, err
 	}
 
 	if savedGitopsCommit.Status == model.ReconciliationSucceeded ||
 		savedGitopsCommit.Status == model.ReconciliationFailed ||
 		savedGitopsCommit.Status == model.ValidationFailed {
-		return nil // don't update state, commit was applied already
+		return false, nil // don't update state, commit was applied already
 	}
 
 	savedGitopsCommit.Status = gitopsCommit.Status
 	savedGitopsCommit.StatusDesc = gitopsCommit.StatusDesc
 	savedGitopsCommit.Created = gitopsCommit.Created
 	savedGitopsCommit.Env = gitopsCommit.Env
-	return meddler.Update(db, "gitops_commits", savedGitopsCommit)
+	return true, meddler.Update(db, "gitops_commits", savedGitopsCommit)
 }
 
-func (db *Store) saveOrUpdateGitopsCommitWithTx(gitopsCommit *model.GitopsCommit) error {
+func (db *Store) saveOrUpdateGitopsCommitWithTx(gitopsCommit *model.GitopsCommit) (bool, error) {
 	stmt := queries.Stmt(db.driver, queries.SelectGitopsCommitBySha)
 	savedGitopsCommit := new(model.GitopsCommit)
 	tx, err := db.Begin()
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer tx.Rollback()
 
@@ -81,28 +80,26 @@ func (db *Store) saveOrUpdateGitopsCommitWithTx(gitopsCommit *model.GitopsCommit
 	if err == sql.ErrNoRows {
 		err = meddler.Insert(db, "gitops_commits", gitopsCommit)
 		if err != nil {
-			return err
+			return false, err
 		}
-		return tx.Commit()
+		return true, tx.Commit()
 	} else if err != nil {
-		return err
+		return false, err
 	}
 
-	logrus.Infof("gtopscommitstatus: %s", savedGitopsCommit.Status)
 	if savedGitopsCommit.Status == model.ReconciliationSucceeded ||
 		savedGitopsCommit.Status == model.ReconciliationFailed ||
 		savedGitopsCommit.Status == model.ValidationFailed {
-		return nil // don't update state, commit was applied already
+		return false, nil // don't update state, commit was applied already
 	}
 
-	logrus.Infof("gtopscommitstatus updating to %s", gitopsCommit.Status)
 	savedGitopsCommit.Status = gitopsCommit.Status
 	savedGitopsCommit.StatusDesc = gitopsCommit.StatusDesc
 	savedGitopsCommit.Created = gitopsCommit.Created
 	savedGitopsCommit.Env = gitopsCommit.Env
 	err = meddler.Update(db, "gitops_commits", savedGitopsCommit)
 	if err != nil {
-		return err
+		return false, err
 	}
-	return tx.Commit()
+	return true, tx.Commit()
 }

--- a/pkg/dashboard/store/gitopsCommit.go
+++ b/pkg/dashboard/store/gitopsCommit.go
@@ -39,16 +39,36 @@ func (db *Store) GitopsCommits() ([]*model.GitopsCommit, error) {
 func (db *Store) SaveOrUpdateGitopsCommit(gitopsCommit *model.GitopsCommit) error {
 	stmt := queries.Stmt(db.driver, queries.SelectGitopsCommitBySha)
 	savedGitopsCommit := new(model.GitopsCommit)
-	err := meddler.QueryRow(db, savedGitopsCommit, stmt, gitopsCommit.Sha)
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	err = meddler.QueryRow(db, savedGitopsCommit, stmt, gitopsCommit.Sha)
 	if err == sql.ErrNoRows {
-		return meddler.Insert(db, "gitops_commits", gitopsCommit)
+		err = meddler.Insert(db, "gitops_commits", gitopsCommit)
+		if err != nil {
+			return err
+		}
+		return tx.Commit()
 	} else if err != nil {
 		return err
+	}
+
+	if savedGitopsCommit.Status == model.ReconciliationSucceeded ||
+		savedGitopsCommit.Status == model.ReconciliationFailed ||
+		savedGitopsCommit.Status == model.ValidationFailed {
+		return nil // don't update state, commit was applied already
 	}
 
 	savedGitopsCommit.Status = gitopsCommit.Status
 	savedGitopsCommit.StatusDesc = gitopsCommit.StatusDesc
 	savedGitopsCommit.Created = gitopsCommit.Created
 	savedGitopsCommit.Env = gitopsCommit.Env
-	return meddler.Update(db, "gitops_commits", savedGitopsCommit)
+	err = meddler.Update(db, "gitops_commits", savedGitopsCommit)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
 }

--- a/pkg/dashboard/store/gitopsCommit.go
+++ b/pkg/dashboard/store/gitopsCommit.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gimlet-io/gimlet-cli/pkg/dashboard/model"
 	queries "github.com/gimlet-io/gimlet-cli/pkg/dashboard/store/sql"
 	"github.com/russross/meddler"
+	"github.com/sirupsen/logrus"
 )
 
 func (db *Store) GitopsCommit(sha string) (*model.GitopsCommit, error) {
@@ -87,12 +88,14 @@ func (db *Store) saveOrUpdateGitopsCommitWithTx(gitopsCommit *model.GitopsCommit
 		return err
 	}
 
+	logrus.Infof("gtopscommitstatus: %s", savedGitopsCommit.Status)
 	if savedGitopsCommit.Status == model.ReconciliationSucceeded ||
 		savedGitopsCommit.Status == model.ReconciliationFailed ||
 		savedGitopsCommit.Status == model.ValidationFailed {
 		return nil // don't update state, commit was applied already
 	}
 
+	logrus.Infof("gtopscommitstatus updating to %s", gitopsCommit.Status)
 	savedGitopsCommit.Status = gitopsCommit.Status
 	savedGitopsCommit.StatusDesc = gitopsCommit.StatusDesc
 	savedGitopsCommit.Created = gitopsCommit.Created

--- a/pkg/dashboard/store/gitopsCommit_test.go
+++ b/pkg/dashboard/store/gitopsCommit_test.go
@@ -17,11 +17,11 @@ func TestGitopsCommitCRUD(t *testing.T) {
 		Sha: "sha",
 	}
 
-	err := s.SaveOrUpdateGitopsCommit(gitopsCommit)
+	_, err := s.SaveOrUpdateGitopsCommit(gitopsCommit)
 	assert.Nil(t, err)
 
 	gitopsCommit.Status = "aStatus"
-	err = s.SaveOrUpdateGitopsCommit(gitopsCommit)
+	_, err = s.SaveOrUpdateGitopsCommit(gitopsCommit)
 	assert.Nil(t, err)
 
 	savedGitopsCommit, err := s.GitopsCommit("sha")

--- a/pkg/dashboard/worker/gitops.go
+++ b/pkg/dashboard/worker/gitops.go
@@ -922,7 +922,7 @@ func saveAndBroadcastGitopsCommit(
 
 	streaming.BroadcastGitopsCommitEvent(clientHub, gitopsCommitToSave)
 
-	err := store.SaveOrUpdateGitopsCommit(&gitopsCommitToSave)
+	_, err := store.SaveOrUpdateGitopsCommit(&gitopsCommitToSave)
 	if err != nil {
 		logrus.Warnf("could not save or update gitops commit: %s", err)
 	}

--- a/web/dashboard/src/redux/redux.js
+++ b/web/dashboard/src/redux/redux.js
@@ -204,6 +204,7 @@ function processStreamingEvent(state, event) {
     case EVENT_STALE_REPO_DATA:
       return eventHandlers.staleRepoData(state, event);
     case EVENT_GITOPS_COMMIT_EVENT:
+      console.log(event);
       return eventHandlers.updateGitopsCommits(state, event);
     case EVENT_COMMIT_STATUS_UPDATED:
       return eventHandlers.updateCommitStatus(state, event);

--- a/web/dashboard/src/views/environments/gitopsAutomationGuide.js
+++ b/web/dashboard/src/views/environments/gitopsAutomationGuide.js
@@ -28,7 +28,7 @@ flux-system   gitops-repo-gimlet-bootstraping-tutorial-dependencies   127m   Tru
                     Now that the gitops automation is in place, every manifest you put in the gitops repositories will be applied on the cluster by the gitops controller.
                 </li>
                 <li className="text-lg font-bold text-blue-800 pt-8">Need to debug Flux?</li>
-                <li>If <code>`kustomizations`</code> or <code>`gitrepositories`</code> are not in ready state, you get an error message in their status.</li>
+                <li>If <code>`kustomizations`</code> or <code>`gitrepositories`</code> are not in ready state, you can see the error message if you run `kubectl describe` on them.</li>
                 <li>If you need to further debug their behavior, you can check Flux logs in the <code>`flux-system`</code> namespace.</li>
                 <CopiableCodeSnippet
                     color="blue"

--- a/web/installer/src/gitopsAutomationGuide.js
+++ b/web/installer/src/gitopsAutomationGuide.js
@@ -25,7 +25,7 @@ flux-system   gitops-repo-gimlet-bootstraping-tutorial-dependencies   127m   Tru
                     Now that the gitops automation is in place, every manifest you put in the gitops repositories will be applied on the cluster by the gitops controller.
                 </li>
                 <li className="text-lg font-bold text-blue-800 pt-8">Need to debug Flux?</li>
-                <li>If <code>`kustomizations`</code> or <code>`gitrepositories`</code> are not in ready state, you get an error message in their status.</li>
+                <li>If <code>`kustomizations`</code> or <code>`gitrepositories`</code> are not in ready state, you can see the error message if you run `kubectl describe` on them.</li>
                 <li>If you need to further debug their behavior, you can check Flux logs in the <code>`flux-system`</code> namespace.</li>
                 <code className="block whitespace-pre overflow-x-scroll font-mono text-xs my-4 p-2 bg-blue-100 text-blue-500 rounded">
                     {`kubectl logs -f deploy/kustomize-controller -n flux-system


### PR DESCRIPTION
This PR addresses two issues with Flux gitops commit statuses
- sometimes the state updates arrive on the server out of order, Gimlet used to think that some commits were not applied because of this
- Also in notification-controller v32 the commit hash format changed. This PR handles both formats