### PR TITLE
Feature: Automated chart version update

### DIFF
--- a/cmd/dashboard/config/config.go
+++ b/cmd/dashboard/config/config.go
@@ -85,7 +85,8 @@ type Config struct {
 	GitSSHAddressFormat     string `envconfig:"GIT_SSH_ADDRESS_FORMAT"`
 	ReleaseStats            string `envconfig:"RELEASE_STATS"`
 
-	TermsOfServiceFeatureFlag bool `envconfig:"FEATURE_TERMS_OF_SERVICE"`
+	TermsOfServiceFeatureFlag      bool `envconfig:"FEATURE_TERMS_OF_SERVICE"`
+	ChartVersionUpdaterFeatureFlag bool `envconfig:"FEATURE_CHART_VERSION_UPDATER"`
 }
 
 // Logging provides the logging configuration.

--- a/cmd/dashboard/config/config.go
+++ b/cmd/dashboard/config/config.go
@@ -42,7 +42,7 @@ func defaults(c *Config) {
 		c.Chart.Repo = "https://chart.onechart.dev"
 	}
 	if c.Chart.Version == "" {
-		c.Chart.Version = "0.41.0"
+		c.Chart.Version = "0.47.0"
 	}
 	if c.GitSSHAddressFormat == "" {
 		c.GitSSHAddressFormat = "git@github.com:%s.git"

--- a/cmd/dashboard/dashboard.go
+++ b/cmd/dashboard/dashboard.go
@@ -128,6 +128,16 @@ func main() {
 	go dashboardRepoCache.Run()
 	log.Info("repo cache initialized")
 
+	if config.ChartVersionUpdaterFeatureFlag {
+		chartVersionUpdater := worker.NewChartVersionUpdater(
+			gitSvc,
+			tokenManager,
+			dashboardRepoCache,
+			goScm,
+		)
+		go chartVersionUpdater.Run()
+	}
+
 	gitopsWorker := worker.NewGitopsWorker(
 		store,
 		config.GitopsRepo,

--- a/cmd/dashboard/dashboard.go
+++ b/cmd/dashboard/dashboard.go
@@ -134,6 +134,7 @@ func main() {
 			tokenManager,
 			dashboardRepoCache,
 			goScm,
+			config.Chart,
 		)
 		go chartVersionUpdater.Run()
 	}

--- a/pkg/dashboard/server/envs.go
+++ b/pkg/dashboard/server/envs.go
@@ -117,7 +117,7 @@ func saveInfrastructureComponents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sourceBranch, err := generateBranchNameWithUniqueHash(fmt.Sprintf("gimlet-stack-change-%s", env.Name), 4)
+	sourceBranch, err := GenerateBranchNameWithUniqueHash(fmt.Sprintf("gimlet-stack-change-%s", env.Name), 4)
 	if err != nil {
 		logrus.Errorf("cannot generate branch name: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -671,7 +671,7 @@ func installAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sourceBranch, err := generateBranchNameWithUniqueHash(fmt.Sprintf("gimlet-stack-change-%s", env.Name), 4)
+	sourceBranch, err := GenerateBranchNameWithUniqueHash(fmt.Sprintf("gimlet-stack-change-%s", env.Name), 4)
 	if err != nil {
 		logrus.Errorf("cannot generate branch name: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/pkg/dashboard/server/gitContents.go
+++ b/pkg/dashboard/server/gitContents.go
@@ -473,7 +473,7 @@ func saveEnvConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// generate branch name to write changes on
-	sourceBranch, err := generateBranchNameWithUniqueHash(fmt.Sprintf("gimlet-config-change-%s", env), 4)
+	sourceBranch, err := GenerateBranchNameWithUniqueHash(fmt.Sprintf("gimlet-config-change-%s", env), 4)
 	if err != nil {
 		logrus.Errorf("cannot generate branch name: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -640,7 +640,7 @@ func hasCiConfigAndShipper(repo *git.Repository, ciConfigPath string, shipperCom
 	return true, findShipper(ciConfigFiles, shipperCommand), nil
 }
 
-func generateBranchNameWithUniqueHash(defaultBranchName string, uniqieHashlength int) (string, error) {
+func GenerateBranchNameWithUniqueHash(defaultBranchName string, uniqieHashlength int) (string, error) {
 	b := make([]byte, uniqieHashlength)
 	_, err := rand.Read(b)
 	if err != nil {
@@ -648,91 +648,4 @@ func generateBranchNameWithUniqueHash(defaultBranchName string, uniqieHashlength
 	}
 
 	return fmt.Sprintf("%s-%s", defaultBranchName, hex.EncodeToString(b)), nil
-}
-
-func UpdateRepoEnvConfigsChartVersion(
-	repoCache *nativeGit.RepoCache,
-	goScm *genericScm.GoScmHelper,
-	token string,
-	repoName string,
-) error {
-	prList, err := goScm.ListOpenPRs(token, repoName)
-	if err != nil {
-		return fmt.Errorf("cannot list pull requests: %s", err)
-	}
-	for _, pullRequest := range prList {
-		if strings.HasPrefix(pullRequest.Source, "gimlet-chart-update") {
-			return nil
-		}
-	}
-
-	repo, tmpPath, err := repoCache.InstanceForWrite(repoName)
-	if err != nil {
-		os.RemoveAll(tmpPath)
-		return fmt.Errorf("could not open %s: %s", repoName, err)
-	}
-
-	headBranch, err := helper.HeadBranch(repo)
-	if err != nil {
-		return fmt.Errorf("cannot get head branch: %s", err)
-	}
-
-	sourceBranch, err := generateBranchNameWithUniqueHash("gimlet-chart-update", 4)
-	if err != nil {
-		return fmt.Errorf("cannot generate branch name: %s", err)
-	}
-
-	err = helper.Branch(repo, fmt.Sprintf("refs/heads/%s", sourceBranch))
-	if err != nil {
-		return fmt.Errorf("cannot checkout branch: %s", err)
-	}
-
-	existingEnvConfigs, err := existingEnvConfigs(repo, headBranch)
-	if err != nil {
-		return fmt.Errorf("cannot get existing configs: %s", err)
-	}
-
-	defaultChartVersion := config.DefaultChart().Version
-	for fileName, content := range existingEnvConfigs {
-		if content.Chart.Repository == "" {
-			continue
-		}
-		content.Chart.Version = defaultChartVersion
-
-		// marshall and ident the manifest
-		var toSaveBuffer bytes.Buffer
-		yamlEncoder := yaml.NewEncoder(&toSaveBuffer)
-		yamlEncoder.SetIndent(2)
-		err = yamlEncoder.Encode(&content)
-		if err != nil {
-			return fmt.Errorf("cannot serialize manifest: %s", err)
-		}
-
-		_ = os.MkdirAll(filepath.Join(tmpPath, ".gimlet"), nativeGit.Dir_RWX_RX_R)
-		err = os.WriteFile(filepath.Join(tmpPath, fmt.Sprintf(".gimlet/%s", fileName)), toSaveBuffer.Bytes(), nativeGit.Dir_RWX_RX_R)
-		if err != nil {
-			return fmt.Errorf("cannot write file: %s", err)
-		}
-	}
-
-	empty, err := nativeGit.NothingToCommit(repo)
-	if err != nil {
-		return fmt.Errorf("cannot get git state: %s", err)
-	}
-	if empty {
-		return nil
-	}
-
-	err = StageCommitAndPush(repo, tmpPath, token, "[Gimlet Dashboard] deployment configurations chart reference verison update")
-	if err != nil {
-		return fmt.Errorf("cannot stage, commit and push: %s", err)
-	}
-
-	_, _, err = goScm.CreatePR(token, repoName, sourceBranch, headBranch,
-		fmt.Sprintf("[Gimlet Dashboard] Upgrade deployment configurations chart reference verison to %s", defaultChartVersion),
-		fmt.Sprintf("deployment configurations chart reference verison upgrade to %s", defaultChartVersion))
-	if err != nil {
-		return fmt.Errorf("cannot create pull request: %s", err)
-	}
-	return nil
 }

--- a/pkg/dashboard/worker/chartVersionUpdater.go
+++ b/pkg/dashboard/worker/chartVersionUpdater.go
@@ -62,6 +62,7 @@ func (c *ChartVersionUpdater) Run() {
 }
 
 func (c *ChartVersionUpdater) updateRepoEnvConfigsChartVersion(token string, repoName string) error {
+	logrus.Infof("evaluating %s for chart version update", repoName)
 	prList, err := c.goScm.ListOpenPRs(token, repoName)
 	if err != nil {
 		return fmt.Errorf("cannot list pull requests: %s", err)
@@ -129,17 +130,18 @@ func (c *ChartVersionUpdater) updateRepoEnvConfigsChartVersion(token string, rep
 		return nil
 	}
 
-	err = server.StageCommitAndPush(repo, tmpPath, token, "[Gimlet Dashboard] deployment configurations chart reference version update")
+	err = server.StageCommitAndPush(repo, tmpPath, token, "[Gimlet] Deployment template update")
 	if err != nil {
 		return fmt.Errorf("cannot stage, commit and push: %s", err)
 	}
 
 	_, _, err = c.goScm.CreatePR(token, repoName, sourceBranch, headBranch,
-		"[Gimlet Dashboard] Upgrade deployment configurations chart reference version",
-		"deployment configurations chart reference version upgrade")
+		"[Gimlet] Deployment template update",
+		"This is an automated Pull Request that updates the Helm chart version in Gimlet manifests.")
 	if err != nil {
 		return fmt.Errorf("cannot create pull request: %s", err)
 	}
+	logrus.Infof("pull request created for %s with chart version update", repoName)
 	return nil
 }
 

--- a/pkg/dashboard/worker/chartVersionUpdater.go
+++ b/pkg/dashboard/worker/chartVersionUpdater.go
@@ -1,0 +1,56 @@
+package worker
+
+import (
+	"time"
+
+	"github.com/gimlet-io/gimlet-cli/pkg/dashboard/server"
+	"github.com/gimlet-io/gimlet-cli/pkg/git/customScm"
+	"github.com/gimlet-io/gimlet-cli/pkg/git/genericScm"
+	"github.com/gimlet-io/gimlet-cli/pkg/git/nativeGit"
+	"github.com/sirupsen/logrus"
+)
+
+type ChartVersionUpdater struct {
+	gitSvc       customScm.CustomGitService
+	tokenManager customScm.NonImpersonatedTokenManager
+	repoCache    *nativeGit.RepoCache
+	goScm        *genericScm.GoScmHelper
+}
+
+func NewChartVersionUpdater(
+	gitSvc customScm.CustomGitService,
+	tokenManager customScm.NonImpersonatedTokenManager,
+	repoCache *nativeGit.RepoCache,
+	goScm *genericScm.GoScmHelper,
+) *ChartVersionUpdater {
+	return &ChartVersionUpdater{
+		gitSvc:       gitSvc,
+		tokenManager: tokenManager,
+		repoCache:    repoCache,
+		goScm:        goScm,
+	}
+}
+
+func (c *ChartVersionUpdater) Run() {
+	for {
+		token, _, _ := c.tokenManager.Token()
+		repos, err := c.gitSvc.OrgRepos(token)
+		if err != nil {
+			logrus.Errorf("cannot get org repos: %s", err)
+		}
+		for _, repoName := range repos {
+			err = server.UpdateRepoEnvConfigsChartVersion(
+				c.repoCache,
+				c.goScm,
+				token,
+				repoName,
+			)
+			if err != nil {
+				logrus.Errorf("cannot update chart versions for %s: %s", repoName, err)
+			}
+		}
+
+		logrus.Info("chart version update process completed")
+		time.Sleep(24 * time.Hour)
+	}
+}

--- a/pkg/dashboard/worker/chartVersionUpdater.go
+++ b/pkg/dashboard/worker/chartVersionUpdater.go
@@ -2,35 +2,43 @@ package worker
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/gimlet-io/gimlet-cli/cmd/dashboard/config"
 	"github.com/gimlet-io/gimlet-cli/pkg/dashboard/server"
+	"github.com/gimlet-io/gimlet-cli/pkg/dx"
 	"github.com/gimlet-io/gimlet-cli/pkg/git/customScm"
 	"github.com/gimlet-io/gimlet-cli/pkg/git/genericScm"
-	"github.com/gimlet-io/gimlet-cli/pkg/git/nativeGit"
+	helper "github.com/gimlet-io/gimlet-cli/pkg/git/nativeGit"
 	"github.com/sirupsen/logrus"
 	giturl "github.com/whilp/git-urls"
+	"sigs.k8s.io/yaml"
 )
 
 type ChartVersionUpdater struct {
 	gitSvc       customScm.CustomGitService
 	tokenManager customScm.NonImpersonatedTokenManager
-	repoCache    *nativeGit.RepoCache
+	repoCache    *helper.RepoCache
 	goScm        *genericScm.GoScmHelper
+	chart        config.Chart
 }
 
 func NewChartVersionUpdater(
 	gitSvc customScm.CustomGitService,
 	tokenManager customScm.NonImpersonatedTokenManager,
-	repoCache *nativeGit.RepoCache,
+	repoCache *helper.RepoCache,
 	goScm *genericScm.GoScmHelper,
+	chart config.Chart,
 ) *ChartVersionUpdater {
 	return &ChartVersionUpdater{
 		gitSvc:       gitSvc,
 		tokenManager: tokenManager,
 		repoCache:    repoCache,
 		goScm:        goScm,
+		chart:        chart,
 	}
 }
 
@@ -42,12 +50,7 @@ func (c *ChartVersionUpdater) Run() {
 			logrus.Errorf("cannot get org repos: %s", err)
 		}
 		for _, repoName := range repos {
-			err = server.UpdateRepoEnvConfigsChartVersion(
-				c.repoCache,
-				c.goScm,
-				token,
-				repoName,
-			)
+			err = c.updateRepoEnvConfigsChartVersion(token, repoName)
 			if err != nil {
 				logrus.Errorf("cannot update chart versions for %s: %s", repoName, err)
 			}
@@ -56,6 +59,88 @@ func (c *ChartVersionUpdater) Run() {
 		logrus.Info("chart version update process completed")
 		time.Sleep(24 * time.Hour)
 	}
+}
+
+func (c *ChartVersionUpdater) updateRepoEnvConfigsChartVersion(token string, repoName string) error {
+	prList, err := c.goScm.ListOpenPRs(token, repoName)
+	if err != nil {
+		return fmt.Errorf("cannot list pull requests: %s", err)
+	}
+	for _, pullRequest := range prList {
+		if strings.HasPrefix(pullRequest.Source, "gimlet-chart-update") {
+			return nil
+		}
+	}
+
+	repo, tmpPath, err := c.repoCache.InstanceForWrite(repoName)
+	if err != nil {
+		os.RemoveAll(tmpPath)
+		return fmt.Errorf("could not open %s: %s", repoName, err)
+	}
+
+	headBranch, err := helper.HeadBranch(repo)
+	if err != nil {
+		return fmt.Errorf("cannot get head branch: %s", err)
+	}
+
+	sourceBranch, err := server.GenerateBranchNameWithUniqueHash("gimlet-chart-update", 4)
+	if err != nil {
+		return fmt.Errorf("cannot generate branch name: %s", err)
+	}
+
+	err = helper.Branch(repo, fmt.Sprintf("refs/heads/%s", sourceBranch))
+	if err != nil {
+		return fmt.Errorf("cannot checkout branch: %s", err)
+	}
+
+	files, err := helper.RemoteFolderOnBranchWithoutCheckout(repo, headBranch, ".gimlet")
+	if err != nil {
+		if !strings.Contains(err.Error(), "directory not found") {
+			return fmt.Errorf("cannot list files in .gimlet/: %s", err)
+		}
+	}
+
+	for fileName, content := range files {
+		latestVersion := c.chart.Version
+
+		chartFromGitRepo, err := isChartFromGitRepo(content)
+		if err != nil {
+			logrus.Warnf("cannot parse manifest string: %s", err)
+			continue
+		}
+		if chartFromGitRepo {
+			latestVersion = c.chart.Name
+		}
+		updatedContent := updateChartVersion(content, latestVersion)
+
+		_ = os.MkdirAll(filepath.Join(tmpPath, ".gimlet"), helper.Dir_RWX_RX_R)
+		err = os.WriteFile(filepath.Join(tmpPath, fmt.Sprintf(".gimlet/%s", fileName)), []byte(updatedContent), helper.Dir_RWX_RX_R)
+		if err != nil {
+			logrus.Warnf("cannot write file in %s: %s", repoName, err)
+			continue
+		}
+	}
+
+	empty, err := helper.NothingToCommit(repo)
+	if err != nil {
+		return fmt.Errorf("cannot get git state: %s", err)
+	}
+	if empty {
+		return nil
+	}
+
+	err = server.StageCommitAndPush(repo, tmpPath, token, "[Gimlet Dashboard] deployment configurations chart reference version update")
+	if err != nil {
+		return fmt.Errorf("cannot stage, commit and push: %s", err)
+	}
+
+	_, _, err = c.goScm.CreatePR(token, repoName, sourceBranch, headBranch,
+		"[Gimlet Dashboard] Upgrade deployment configurations chart reference version",
+		"deployment configurations chart reference version upgrade")
+	if err != nil {
+		return fmt.Errorf("cannot create pull request: %s", err)
+	}
+	return nil
 }
 
 func updateChartVersion(raw string, latestVersion string) string {
@@ -75,4 +160,13 @@ func updateChartVersion(raw string, latestVersion string) string {
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+func isChartFromGitRepo(content string) (bool, error) {
+	var manifest dx.Manifest
+	err := yaml.Unmarshal([]byte(content), &manifest)
+	if err != nil {
+		return false, err
+	}
+	return strings.HasPrefix(manifest.Chart.Name, "git@") || strings.Contains(manifest.Chart.Name, ".git"), nil
 }

--- a/pkg/dashboard/worker/chartVersionUpdater.go
+++ b/pkg/dashboard/worker/chartVersionUpdater.go
@@ -54,3 +54,7 @@ func (c *ChartVersionUpdater) Run() {
 		time.Sleep(24 * time.Hour)
 	}
 }
+
+func updateChartVersion(manifestString string, latestVersion string) string {
+	return manifestString
+}

--- a/pkg/dashboard/worker/chartVersionUpdater_test.go
+++ b/pkg/dashboard/worker/chartVersionUpdater_test.go
@@ -71,3 +71,22 @@ values: {}
 	assert.Empty(t, updatedManifest.Chart.Version)
 	assert.Empty(t, updatedManifest.Chart.Repository)
 }
+
+func Test_updatingOnlyTheHashInHelmChartGitRepo(t *testing.T) {
+	raw := `app: 'gimlet-dashboard'
+env: staging
+namespace: 'default'
+chart:
+  name: git@github.com:gimlet-io/onechart.git?sha=a988d33fdff367d6f8efddfeb311b2b1c74c8ff2&path=/charts/cron-job/
+values: {}
+`
+
+	latestVersion := "git@github.com:gimlet-io/onechart.git?sha=abcdef&path=/charts/onechart/"
+
+	updated := updateChartVersion(raw, latestVersion)
+
+	var updatedManifest dx.Manifest
+	yaml.Unmarshal([]byte(updated), &updatedManifest)
+
+	assert.Equal(t, "git@github.com:gimlet-io/onechart.git?sha=abcdef&path=/charts/cron-job/", updatedManifest.Chart.Name)
+}

--- a/pkg/dashboard/worker/chartVersionUpdater_test.go
+++ b/pkg/dashboard/worker/chartVersionUpdater_test.go
@@ -1,0 +1,51 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/gimlet-io/gimlet-cli/pkg/dx"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func Test_updatingHelmChart(t *testing.T) {
+	raw := `app: 'gimlet-dashboard'
+env: staging
+namespace: 'default'
+chart:
+  repository: https://chart.onechart.dev
+  name: onechart
+  version: 0.39.0
+values: {}
+`
+
+	latestVersion := "0.47.0"
+
+	updated := updateChartVersion(raw, latestVersion)
+
+	var updatedManifest dx.Manifest
+	yaml.Unmarshal([]byte(updated), &updatedManifest)
+
+	assert.Equal(t, latestVersion, updatedManifest.Chart.Version)
+}
+
+func Test_updatingHelmChartInGitRepo(t *testing.T) {
+	raw := `app: 'gimlet-dashboard'
+env: staging
+namespace: 'default'
+chart:
+  name: https://github.com/raffle-ai/onechart.git?sha=a988d33fdff367d6f8efddfeb311b2b1c74c8ff2&path=/charts/onechart/
+values: {}
+`
+
+	latestVersion := "https://github.com/raffle-ai/onechart.git?sha=abcdef&path=/charts/onechart/"
+
+	updated := updateChartVersion(raw, latestVersion)
+
+	var updatedManifest dx.Manifest
+	yaml.Unmarshal([]byte(updated), &updatedManifest)
+
+	assert.Equal(t, latestVersion, updatedManifest.Chart.Name)
+	assert.Empty(t, latestVersion, updatedManifest.Chart.Version)
+	assert.Empty(t, latestVersion, updatedManifest.Chart.Repository)
+}

--- a/pkg/dashboard/worker/chartVersionUpdater_test.go
+++ b/pkg/dashboard/worker/chartVersionUpdater_test.go
@@ -27,9 +27,10 @@ values: {}
 	yaml.Unmarshal([]byte(updated), &updatedManifest)
 
 	assert.Equal(t, latestVersion, updatedManifest.Chart.Version)
+	assert.Equal(t, "onechart", updatedManifest.Chart.Name)
 }
 
-func Test_updatingHelmChartInGitRepo(t *testing.T) {
+func Test_updatingHelmChartInGitRepoHTTPSScheme(t *testing.T) {
 	raw := `app: 'gimlet-dashboard'
 env: staging
 namespace: 'default'
@@ -46,6 +47,27 @@ values: {}
 	yaml.Unmarshal([]byte(updated), &updatedManifest)
 
 	assert.Equal(t, latestVersion, updatedManifest.Chart.Name)
-	assert.Empty(t, latestVersion, updatedManifest.Chart.Version)
-	assert.Empty(t, latestVersion, updatedManifest.Chart.Repository)
+	assert.Empty(t, updatedManifest.Chart.Version)
+	assert.Empty(t, updatedManifest.Chart.Repository)
+}
+
+func Test_updatingHelmChartInGitRepoSSHScheme(t *testing.T) {
+	raw := `app: 'gimlet-dashboard'
+env: staging
+namespace: 'default'
+chart:
+  name: git@github.com:gimlet-io/onechart.git?sha=a988d33fdff367d6f8efddfeb311b2b1c74c8ff2&path=/charts/onechart/
+values: {}
+`
+
+	latestVersion := "git@github.com:gimlet-io/onechart.git?sha=abcdef&path=/charts/onechart/"
+
+	updated := updateChartVersion(raw, latestVersion)
+
+	var updatedManifest dx.Manifest
+	yaml.Unmarshal([]byte(updated), &updatedManifest)
+
+	assert.Equal(t, latestVersion, updatedManifest.Chart.Name)
+	assert.Empty(t, updatedManifest.Chart.Version)
+	assert.Empty(t, updatedManifest.Chart.Repository)
 }

--- a/pkg/dashboard/worker/chartVersionUpdater_test.go
+++ b/pkg/dashboard/worker/chartVersionUpdater_test.go
@@ -35,11 +35,11 @@ func Test_updatingHelmChartInGitRepoHTTPSScheme(t *testing.T) {
 env: staging
 namespace: 'default'
 chart:
-  name: https://github.com/raffle-ai/onechart.git?sha=a988d33fdff367d6f8efddfeb311b2b1c74c8ff2&path=/charts/onechart/
+  name: https://github.com/my-fork/onechart.git?sha=a988d33fdff367d6f8efddfeb311b2b1c74c8ff2&path=/charts/onechart/
 values: {}
 `
 
-	latestVersion := "https://github.com/raffle-ai/onechart.git?sha=abcdef&path=/charts/onechart/"
+	latestVersion := "https://github.com/my-fork/onechart.git?sha=abcdef&path=/charts/onechart/"
 
 	updated := updateChartVersion(raw, latestVersion)
 

--- a/pkg/dashboard/worker/gitops_test.go
+++ b/pkg/dashboard/worker/gitops_test.go
@@ -15,7 +15,6 @@
 package worker
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -411,48 +410,6 @@ cleanup:
 		Environments: []*dx.Manifest{&many},
 	}
 	assert.True(t, a.HasCleanupPolicy())
-}
-
-func Test_keepFieldOrder(t *testing.T) {
-	raw := `app: 'gimlet-dashboard'
-env: staging
-namespace: 'default'
-chart:
-  repository: https://chart.onechart.dev
-  name: onechart
-  version: 0.39.0
-values:
-  containerPort: 9000
-  gitRepository: gimlet-io/gimlet
-  gitSha: '{{ .SHA }}'
-  image:
-    repository: ghcr.io/gimlet-io/gimlet
-    tag: v0.15.6
-    pullPolicy: Always
-  probe:
-    enabled: true
-    path: /health
-  volumes:
-    - name: repo-cache
-      path: /tmp/gimlet-dashboard
-      size: 5Gi
-  ingress:
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
-    tlsEnabled: true
-    host: 'gimlet.gimlet.io'
-`
-
-	var manifest dx.Manifest
-	yaml.Unmarshal([]byte(raw), &manifest)
-
-	var toSaveBuffer bytes.Buffer
-	yamlEncoder := yaml.NewEncoder(&toSaveBuffer)
-	yamlEncoder.SetIndent(2)
-	err := yamlEncoder.Encode(&manifest)
-	assert.Nil(t, err)
-	fmt.Println(raw)
-	fmt.Println(toSaveBuffer.String())
 }
 
 func Test_revertTo(t *testing.T) {


### PR DESCRIPTION
With 
- `FEATURE_CHART_VERSION_UPDATER: "true"`
- and `CHART_NAME: https://github.com/my-fork/onechart.git?sha=12670de9559287846ee2b52229f9f0561b3ea614&path=/charts/onechart/`
- or CHART_VERSION=`v0.47.0`
set.

Gimlet will file PRs in repos that use an outdated Helm cahrt for deployment.

Kind of how dependabot or snyk does it.

This helps teams with large number of repos, to keep things up to date.