### PR TITLE
Removed accidental coupling

### DIFF
--- a/cmd/dashboard/config/config.go
+++ b/cmd/dashboard/config/config.go
@@ -7,6 +7,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const DEFAULT_CHART_NAME = "onechart"
+const DEFAULT_CHART_REPO = "https://chart.onechart.dev"
+const DEFAULT_CHART_VERSION = "0.47.0"
+
 // Environ returns the settings from the environment.
 func Environ() (*Config, error) {
 	cfg := Config{}
@@ -14,12 +18,6 @@ func Environ() (*Config, error) {
 	defaults(&cfg)
 
 	return &cfg, err
-}
-
-func DefaultChart() Chart {
-	cfg := Config{}
-	defaults(&cfg)
-	return cfg.Chart
 }
 
 func defaults(c *Config) {
@@ -36,13 +34,13 @@ func defaults(c *Config) {
 		c.ReleaseHistorySinceDays = 30
 	}
 	if c.Chart.Name == "" {
-		c.Chart.Name = "onechart"
+		c.Chart.Name = DEFAULT_CHART_NAME
 	}
 	if c.Chart.Repo == "" {
-		c.Chart.Repo = "https://chart.onechart.dev"
+		c.Chart.Repo = DEFAULT_CHART_REPO
 	}
 	if c.Chart.Version == "" {
-		c.Chart.Version = "0.47.0"
+		c.Chart.Version = DEFAULT_CHART_VERSION
 	}
 	if c.GitSSHAddressFormat == "" {
 		c.GitSSHAddressFormat = "git@github.com:%s.git"

--- a/pkg/commands/manifest/configure.go
+++ b/pkg/commands/manifest/configure.go
@@ -203,8 +203,7 @@ func helmChartInfo(chart string) (string, string, string, error) {
 		return chartName, repoUrl, chartVersion, nil
 	}
 
-	defaultChart := config.DefaultChart()
-	return defaultChart.Name, defaultChart.Repo, defaultChart.Version, nil
+	return config.DEFAULT_CHART_NAME, config.DEFAULT_CHART_REPO, config.DEFAULT_CHART_VERSION, nil
 }
 
 func setManifestValues(m *dx.Manifest, values manifestValues) {


### PR DESCRIPTION
We use the config struct to configure the gimlet app. This PR removes the coupling between the CLI and the `config` struct.

Somehow the CLI instantiated a config struct - due to programmer convenience probably, but this is complicating the refactoring of the config struct. Thus it is cleaned up now.