### PR TITLE
Helm setup on the action runner and onechart helm repo add

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,13 @@ jobs:
       uses: styfle/cancel-workflow-action@0.9.1
       with:
         access_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v3
+      with:
+        version: 3.11.1
+        token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Set up Go
       uses: actions/setup-go@v4
       with:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ test-prep:
 	touch pkg/commands/chart/bundle.js
 	touch pkg/commands/chart/bundle.js.LICENSE.txt
 	touch pkg/commands/chart/index.html
+	helm repo add onechart https://chart.onechart.dev
 
 test: test-prep
 	go test -timeout 60s $(shell go list ./...)


### PR DESCRIPTION
Fixes the test failures on CI: https://github.com/gimlet-io/gimlet/actions/runs/5769209581/job/15641013308#step:9:263

@laszlocph the helm configuration might not be needed on the runner, but I have no access to test it, so I'm adding it to make sure. Alternatively I could disable that test case and not bother with helm setup on the runner just for a single test, but this could give room for potentially more tests like this one in the future. Wdyt?