### PR TITLE
Add wolfi based images and build steps

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -73,3 +73,12 @@ jobs:
         push: true
         tags: |
           ghcr.io/gimlet-io/gimlet-cli:${{ steps.version.outputs.version }}
+    - name: Build and push Docker image (Wolfi)
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: docker/cli/Dockerfile.wolfi
+        platforms: linux/amd64
+        push: true
+        tags: |
+          ghcr.io/gimlet-io/gimlet-cli-wolfi:${{ steps.version.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,3 +76,21 @@ jobs:
         push: true
         tags: |
           ghcr.io/gimlet-io/gimlet:agent-${{ steps.version.outputs.version }}
+    - name: Build and push Gimlet image (Wolfi)
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: docker/dashboard/Dockerfile.wolfi
+        platforms: linux/amd64,linux/arm64/v8
+        push: true
+        tags: |
+          ghcr.io/gimlet-io/gimlet-wolfi:${{ steps.version.outputs.version }}
+    - name: Build and push Agent image (Wolfi)
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: docker/dashboard/Dockerfile.wolfi.agent
+        platforms: linux/amd64,linux/arm64/v8
+        push: true
+        tags: |
+          ghcr.io/gimlet-io/gimlet:agent-wolfi-${{ steps.version.outputs.version }}

--- a/docker/cli/Dockerfile.wolfi
+++ b/docker/cli/Dockerfile.wolfi
@@ -1,0 +1,7 @@
+FROM cgr.dev/chainguard/wolfi-base:latest
+
+RUN apk --no-cache add bash curl git openssl jq
+
+WORKDIR /action
+
+ADD bin/gimlet-linux-x86_64 /bin/gimlet

--- a/docker/dashboard/Dockerfile.wolfi
+++ b/docker/dashboard/Dockerfile.wolfi
@@ -1,0 +1,32 @@
+FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/wolfi-base:latest
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh
+
+ENV DATABASE_DRIVER=sqlite
+ENV DATABASE_CONFIG=/var/lib/gimlet-dashboard/gimlet-dashboard.sqlite?_pragma=busy_timeout=10000
+ENV XDG_CACHE_HOME /var/lib/gimlet-dashboard
+ENV GIT_ROOT=/var/lib/gimlet-dashboard/git-root/
+
+RUN addgroup -S gimlet-dashboard && adduser -S gimlet-dashboard -G gimlet-dashboard
+
+ADD docker/dashboard/known_hosts /etc/ssh/ssh_known_hosts
+
+RUN mkdir /var/lib/gimlet-dashboard
+RUN chown gimlet-dashboard:gimlet-dashboard /var/lib/gimlet-dashboard
+WORKDIR /gimlet-dashboard
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+COPY --chown=gimlet-dashboard:gimlet-dashboard bin/${TARGETPLATFORM}/gimlet-dashboard gimlet-dashboard
+COPY --chown=gimlet-dashboard:gimlet-dashboard web/dashboard/build ./web/build/
+
+USER gimlet-dashboard
+
+RUN git config --global user.name "Gimlet"
+RUN git config --global user.email "gimlet@gimlet.io"
+RUN git config --global init.defaultBranch main
+
+EXPOSE 9000
+CMD ["/gimlet-dashboard/gimlet-dashboard"]

--- a/docker/dashboard/Dockerfile.wolfi.agent
+++ b/docker/dashboard/Dockerfile.wolfi.agent
@@ -1,0 +1,21 @@
+FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/wolfi-base:latest
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash openssh
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+ADD bin/${TARGETPLATFORM}/gimlet-agent /bin/gimlet-agent
+
+RUN addgroup -S gimlet-agent && adduser -S gimlet-agent -G gimlet-agent
+
+ADD docker/dashboard/known_hosts /etc/ssh/ssh_known_hosts
+
+RUN mkdir /var/lib/gimlet-agent
+RUN chown gimlet-agent:gimlet-agent /var/lib/gimlet-agent
+
+USER gimlet-agent
+WORKDIR /var/lib/gimlet-agent
+
+CMD ["/bin/gimlet-agent"]


### PR DESCRIPTION
Adding new Dockerfiles and build steps to have the ability to test the new images before completely switching to it. Since Wolfi is also using `apk` just like Alpine, so there shouldn't be any issues with compatibility, but a thorough testing is required before switching to it completely.

I don't think the Jammy builders should be switched for now.

I haven't found previous Wolfi image versions, their history page only lists `latest` at the time of writing: https://edu.chainguard.dev/chainguard/chainguard-images/reference/wolfi-base/tags_history/

Arm64 is also available: https://www.chainguard.dev/unchained/building-wolfi-from-the-ground-up-and-announcing-arm64-support