### PR TITLE
Using latest in the major version, prioritizing security over stability

### DIFF
--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.1
+FROM alpine:3
 
 RUN apk --no-cache add bash curl git openssl jq
 

--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM alpine:3.17.1
+FROM --platform=$BUILDPLATFORM alpine:3
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh

--- a/docker/dashboard/Dockerfile.agent
+++ b/docker/dashboard/Dockerfile.agent
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM alpine:3.17.1
+FROM --platform=$BUILDPLATFORM alpine:3
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash openssh


### PR DESCRIPTION
Hacking with @mamayer19. Using the latest of a major version will spare us some manual version updates, and we are better prepared for security fixes, sacrificing some stability, but it is probably fine.

