### PR TITLE
Upgrade posthog-js from 1.83.0 to 1.88.1

### DIFF
--- a/web/dashboard/package-lock.json
+++ b/web/dashboard/package-lock.json
@@ -23,7 +23,7 @@
         "helm-react-ui": "github:gimlet-io/helm-react-ui#master",
         "js-yaml": "^4.1.0",
         "nanoid": "^3.3.6",
-        "posthog-js": "^1.83.0",
+        "posthog-js": "^1.88.1",
         "react": "^16.5.2",
         "react-diff-viewer": "^3.1.1",
         "react-dom": "^16.5.2",
@@ -12840,9 +12840,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/posthog-js": {
-      "version": "1.83.0",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.83.0.tgz",
-      "integrity": "sha512-3dp/yNbRCYsOgvJovFUMCLv9/KxnwmGBy5Ft27Q7/rbW++iJXVR64liX7i0NrXkudjoL9j1GW1LGh84rV7kv8Q==",
+      "version": "1.88.1",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.88.1.tgz",
+      "integrity": "sha512-+8kFFU5KIcFSm8zB3tX8l0GSPyq/OtMtdrS9dYpMJk6nsEwXvOjkwFEpSrYzL5eGEpTPdbM65M52HvMqqsjpXw==",
       "dependencies": {
         "fflate": "^0.4.1"
       }
@@ -25689,9 +25689,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "posthog-js": {
-      "version": "1.83.0",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.83.0.tgz",
-      "integrity": "sha512-3dp/yNbRCYsOgvJovFUMCLv9/KxnwmGBy5Ft27Q7/rbW++iJXVR64liX7i0NrXkudjoL9j1GW1LGh84rV7kv8Q==",
+      "version": "1.88.1",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.88.1.tgz",
+      "integrity": "sha512-+8kFFU5KIcFSm8zB3tX8l0GSPyq/OtMtdrS9dYpMJk6nsEwXvOjkwFEpSrYzL5eGEpTPdbM65M52HvMqqsjpXw==",
       "requires": {
         "fflate": "^0.4.1"
       }

--- a/web/dashboard/package.json
+++ b/web/dashboard/package.json
@@ -18,7 +18,7 @@
     "helm-react-ui": "github:gimlet-io/helm-react-ui#master",
     "js-yaml": "^4.1.0",
     "nanoid": "^3.3.6",
-    "posthog-js": "^1.83.0",
+    "posthog-js": "^1.88.1",
     "react": "^16.5.2",
     "react-diff-viewer": "^3.1.1",
     "react-dom": "^16.5.2",


### PR DESCRIPTION
Tried to install `posthog-js@1.89.0`, got: `npm ERR! notarget No matching version found for posthog-js@1.89.0.`.
So installed `posthog-js@latest`.